### PR TITLE
fix: use ipld-core instead of libipld

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,9 @@ name = "rs_car_sync"
 path = "src/lib.rs"
 
 [dependencies]
-libipld = { version = ">=0.14, <0.17", default-features = false, features = [
-    "dag-cbor",
-] }
 blake2b_simd = { version = "1.0", default-features = false }
+ipld-core = { version = "0.4.2", default-features = false }
+serde_ipld_dagcbor = { version = "0.6.3", default-features = false }
 sha2 = { version = "0.10", default-features = false }
 
 [dev-dependencies]

--- a/src/block_cid.rs
+++ b/src/block_cid.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 
 use blake2b_simd::Params;
-use libipld::{cid, multihash::MultihashGeneric};
+use ipld_core::cid::{self, multihash::Multihash};
 use sha2::{Digest, Sha256};
 
 use crate::{
@@ -24,7 +24,7 @@ pub(crate) fn read_block_cid<R: Read>(src: &mut R) -> Result<(Cid, usize), CarDe
     if [version, codec] == [CODE_SHA2_256, 0x20] {
         let mut digest = [0u8; CID_V0_MH_SIZE];
         src.read_exact(&mut digest)?;
-        let mh = MultihashGeneric::wrap(version, &digest).expect("Digest is always 32 bytes.");
+        let mh = Multihash::wrap(version, &digest).expect("Digest is always 32 bytes.");
         return Ok((Cid::new_v0(mh)?, version_len + codec_len + CID_V0_MH_SIZE));
     }
 
@@ -45,9 +45,7 @@ pub(crate) fn read_block_cid<R: Read>(src: &mut R) -> Result<(Cid, usize), CarDe
     }
 }
 
-fn read_multihash<R: Read>(
-    r: &mut R,
-) -> Result<(MultihashGeneric<DIGEST_SIZE>, usize), CarDecodeError> {
+fn read_multihash<R: Read>(r: &mut R) -> Result<(Multihash<DIGEST_SIZE>, usize), CarDecodeError> {
     let (code, code_len) = read_varint_u64(r)?.ok_or(CarDecodeError::InvalidMultihash(
         "invalid code varint".to_string(),
     ))?;
@@ -65,7 +63,7 @@ fn read_multihash<R: Read>(
     // TODO: Sad, copies the digest (again)..
     // Multihash does not expose a way to construct Self without some decoding or copying
     // unwrap: multihash must be valid since it's constructed manually
-    let mh = MultihashGeneric::wrap(code, &digest[..size as usize]).unwrap();
+    let mh = Multihash::wrap(code, &digest[..size as usize]).unwrap();
 
     Ok((mh, code_len + size_len + size as usize))
 }
@@ -129,10 +127,7 @@ fn hash_blake2b_256(data: &[u8]) -> [u8; 32] {
 mod tests {
     use std::io::{self, Cursor};
 
-    use libipld::cid::{
-        multihash::{Multihash, MultihashGeneric},
-        Cid,
-    };
+    use ipld_core::cid::{multihash::Multihash, Cid};
 
     use super::{assert_block_cid, read_block_cid, read_multihash};
     use crate::{block_cid::CODE_SHA2_256, error::CarDecodeError};
@@ -164,7 +159,7 @@ mod tests {
     #[test]
     fn read_multihash_from_v0() {
         let digest = hex::decode(CID_DIGEST).unwrap();
-        let mh_expected = MultihashGeneric::<64>::wrap(CODE_SHA2_256, &digest).unwrap();
+        let mh_expected = Multihash::<64>::wrap(CODE_SHA2_256, &digest).unwrap();
 
         let mut input_stream = from_hex(CID_V0_HEX);
         let (mh, mh_len) = read_multihash(&mut input_stream).unwrap();
@@ -173,7 +168,7 @@ mod tests {
         assert_eq!(mh_len, mh_expected.to_bytes().len());
 
         // Sanity check, same result as sync version. Sync API can dynamically shrink size to 32 bytes
-        let mh_sync = Multihash::read(&mut mh_expected.to_bytes().as_slice()).unwrap();
+        let mh_sync = Multihash::<64>::read(&mut mh_expected.to_bytes().as_slice()).unwrap();
         assert_eq!(mh_sync, mh_expected);
     }
 

--- a/src/carv1_header.rs
+++ b/src/carv1_header.rs
@@ -1,4 +1,4 @@
-use libipld::{cbor::DagCborCodec, cid::Cid, prelude::*, Ipld};
+use ipld_core::{cid::Cid, ipld::Ipld};
 
 use crate::error::CarDecodeError;
 
@@ -15,7 +15,7 @@ pub(crate) struct CarV1Header {
 /// [varint][DAG-CBOR block][varint|CID|block][varint|CID|block]
 /// ```
 pub(crate) fn decode_carv1_header(header: &[u8]) -> Result<CarV1Header, CarDecodeError> {
-    let header: Ipld = DagCborCodec.decode(header).map_err(|e| {
+    let header: Ipld = serde_ipld_dagcbor::from_slice(header).map_err(|e| {
         CarDecodeError::InvalidCarV1Header(format!("header cbor codec error: {e:?}"))
     })?;
 
@@ -100,7 +100,7 @@ mod tests {
         match decode_carv1_header(&header_buf) {
             Err(CarDecodeError::InvalidCarV1Header(str)) => assert_eq!(
                 str,
-                "header cbor codec error: invalid utf-8 sequence of 1 bytes from index 0"
+                "header cbor codec error: InvalidUtf8(Utf8Error { valid_up_to: 0, error_len: Some(1) })"
             ),
             x => panic!("other result {:?}", x),
         }
@@ -112,7 +112,7 @@ mod tests {
 
         match decode_carv1_header(&header_buf) {
             Err(CarDecodeError::InvalidCarV1Header(str)) => {
-                assert_eq!(str, "header expected cbor Map but got Integer(0)")
+                assert_eq!(str, "header cbor codec error: TrailingData")
             }
             x => panic!("other result {:?}", x),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use libipld::cid::{self, multihash, Cid};
+use ipld_core::cid::{self, multihash, Cid};
 
 #[derive(Debug)]
 pub enum CarDecodeError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 use std::io::Read;
 
-pub use libipld::cid::Cid;
+pub use ipld_core::cid::Cid;
 
 use crate::{
     block_cid::assert_block_cid,

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -59,7 +59,7 @@ macro_rules! error_test {
 error_test!(
     bad_cid_v0,
     "3aa265726f6f747381d8305825000130302030303030303030303030303030303030303030303030303030303030303030306776657273696f6e010130",
-    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: Unknown cbor tag `48`.\")"),
+    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: TypeMismatch { name: \\\"CBOR tag\\\", byte: 48 }\")"),
     TestOptions::None
 );
 
@@ -80,7 +80,7 @@ error_test!(
 error_test!(
     bad_section_length_2,
     "3aa265726f6f747381d8305825000130302030303030303030303030303030303030303030303030303030303030303030306776657273696f6e01200130302030303030303030303030303030303030303030303030303030303030303030303030303030303030",
-    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: Unknown cbor tag `48`.\")"),
+    TestResult::Error("InvalidCarV1Header(\"header cbor codec error: TypeMismatch { name: \\\"CBOR tag\\\", byte: 48 }\")"),
     TestOptions::None
 );
 


### PR DESCRIPTION
The `libipld` library is deprecated. `ipld-core` should be used instead. This commit makes that switch.